### PR TITLE
ignore .project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 hs_err_pid*
 
 .idea/
+.project


### PR DESCRIPTION
root can be imported in Eclipse as general project